### PR TITLE
Add <numeric> to tensor/IndexMapping.cpp for std::iota

### DIFF
--- a/tensor/IndexMapping.cpp
+++ b/tensor/IndexMapping.cpp
@@ -5,6 +5,7 @@
 
 #include "IndexMapping.hpp"
 #include <algorithm>
+#include <numeric>
 
 namespace acro
 {
@@ -36,7 +37,7 @@ void IndexMapping::ComputeInverse()
     {
         InvMOff[i] = off;
         if (off < RangeSize)
-        {       
+        {
             int m = M[InvM[off]];
             while (off < RangeSize && M[InvM[off]] == m)
             {
@@ -56,7 +57,7 @@ void IndexMapping::ComputeInverse()
         InvM.SwitchFromGPU();
         InvM.MoveToGPU();
         InvMOff.SwitchFromGPU();
-        InvMOff.MoveToGPU();        
+        InvMOff.MoveToGPU();
     }
 }
 


### PR DESCRIPTION
This is needed to fix a compilation error with GCC 8. As a side effect, my editor removed some extra whitespace at the end of a couple lines.